### PR TITLE
Fix error when using `Recalculate_Powered_Entities`

### DIFF
--- a/Powered_Entities_0.3.4/scripts.lua
+++ b/Powered_Entities_0.3.4/scripts.lua
@@ -215,11 +215,13 @@ function destroyAllInvisablePoles(force)
 	local forcePoles = Surface.find_all_entities({force=force, type="electric-pole"})
 	
 	for _, entity in pairs(forcePoles) do
-		for _, listEntity in ipairs(allInvisablePowerPoles) do
-			if (entity.name == listEntity) then
-				entity.destroy()
-				break
-			end
+      if entity.valid then
+		   for _, listEntity in ipairs(allInvisablePowerPoles) do
+            if (entity.name == listEntity) then
+				   entity.destroy()
+				   break
+			   end
+         end
 		end
 	end
 end


### PR DESCRIPTION
This fixes an error I got when recalculating poles (while removing auto-poles from lamps, to make displays clearer).
